### PR TITLE
Added force_verify to strategy parameters

### DIFF
--- a/lib/passport-twitchtv/strategy.js
+++ b/lib/passport-twitchtv/strategy.js
@@ -48,6 +48,11 @@ function Strategy(options, verify) {
   OAuth2Strategy.call(this, options, verify);
   this.name = 'twitchtv';
 
+  // Sets Twitch's force_verify parameter. Defaults to false
+  OAuth2Strategy.prototype.authorizationParams = function() {
+    return { force_verify: options.force_verify };
+  }
+
   // Twitch has some non-standard requirements that we need to adjust
   this._oauth2.setAuthMethod('OAuth');
   this._oauth2.useAuthorizationHeaderforGET(true);


### PR DESCRIPTION
Twitch supports a [force_verify](https://github.com/justintv/Twitch-API/blob/master/authentication.md) parameter during authentication. I added a line to support this using passport-oauth2's function for extra parameters. An optional `force_verify: true` can be added when initializing the passport-twitchtv strategy.
